### PR TITLE
Display scratch answers in a faint font

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -18,6 +18,7 @@
     <color name="currentLetterHighlightColor">@color/accent</color>
     <color name="cheatedColor">#553333</color>
     <color name="boardLetterColor">#aaa</color>
+    <color name="boardNoteColor">#80aaaaaa</color>
     <color name="titleTextColor">@color/textColorPrimary</color>
     <color name="progressNull">#b4b4b4</color>
     <color name="progressInProgress">#d5a518</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -18,6 +18,7 @@
     <color name="currentLetterHighlightColor">#EB6000</color>
     <color name="cheatedColor">#FFE0E0</color>
     <color name="boardLetterColor">#000</color>
+    <color name="boardNoteColor">#60000000</color>
     <color name="titleTextColor">#fff</color>
     <color name="progressNull">#b4b4b4</color>
     <color name="progressInProgress">#d5a518</color>


### PR DESCRIPTION
Hi - I came across your Shortyz fork and I'm interested in contributing some improvements.  This is a simple one to get started.

This changes how the scratch note is displayed in the main grid.  Instead of using a smaller font, it uses a thinner font and a lighter colour (setting the alpha so that it works on the highlighted background too). 

Tested on day/night mode and looks okay to me.  No need to test with error highlighting, because you don't get errors on scratch notes.
![image](https://user-images.githubusercontent.com/3322888/103486911-379a8100-4df9-11eb-90f9-9195a455614d.png)
![image](https://user-images.githubusercontent.com/3322888/103486915-408b5280-4df9-11eb-8211-ee857417baac.png)
![image](https://user-images.githubusercontent.com/3322888/103486887-1e91d000-4df9-11eb-8a5a-892908ac11e8.png)
![image](https://user-images.githubusercontent.com/3322888/103486896-281b3800-4df9-11eb-8023-8340f19b6d88.png)

Hopefully you're okay with this change - I think it looks a bit better, plus my eyesight isn't what it used to be so the small font isn't ideal!

Could you also let me know your thoughts on the next change I would like to make, which is to add a pencil/pen toggle so that you can add scratch notes directly in the grid.  For simplicity I would probably put the toggle in the menu initially (like Show Errors).