### PR TITLE
Refactor menus to use resource files

### DIFF
--- a/app/src/main/java/app/crossword/yourealwaysbe/BrowseActivity.java
+++ b/app/src/main/java/app/crossword/yourealwaysbe/BrowseActivity.java
@@ -26,8 +26,8 @@ import androidx.recyclerview.widget.ItemTouchHelper;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.SubMenu;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
@@ -195,28 +195,15 @@ public class BrowseActivity extends ForkyzActivity implements RecyclerItemClickL
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        super.onCreateOptionsMenu(menu);
-        if(utils.isNightModeAvailable()) {
-            utils.onActionBarWithoutText(menu.add("App Theme")
-                    .setIcon(getNightModeIcon()));
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.browse_menu, menu);
+
+        if (utils.isNightModeAvailable()) {
+            MenuItem item = menu.findItem(R.id.browse_menu_app_theme);
+            if (item != null) item.setIcon(getNightModeIcon());
+        } else {
+            menu.removeItem(R.id.browse_menu_app_theme);
         }
-        SubMenu sortMenu = menu.addSubMenu("Sort")
-                               .setIcon(android.R.drawable.ic_menu_sort_alphabetically);
-        sortMenu.add("By Date (Descending)")
-                .setIcon(android.R.drawable.ic_menu_day);
-        sortMenu.add("By Date (Ascending)")
-                .setIcon(android.R.drawable.ic_menu_day);
-        sortMenu.add("By Source")
-                .setIcon(android.R.drawable.ic_menu_upload);
-        utils.onActionBarWithText(sortMenu);
-        menu.add("Cleanup")
-            .setIcon(android.R.drawable.ic_menu_manage);
-        menu.add(MENU_ARCHIVES)
-            .setIcon(android.R.drawable.ic_menu_view);
-        menu.add("Help")
-            .setIcon(android.R.drawable.ic_menu_help);
-        menu.add("Settings")
-            .setIcon(android.R.drawable.ic_menu_preferences);
 
         return true;
     }
@@ -244,26 +231,17 @@ public class BrowseActivity extends ForkyzActivity implements RecyclerItemClickL
     @SuppressWarnings("deprecation")
 	@Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if(item == null || item.getTitle() == null){
-            return false;
-        }
-        if(item.getTitle().equals("App Theme")){
+        switch (item.getItemId()) {
+        case R.id.browse_menu_app_theme:
             this.utils.nextNightMode(this);
             item.setIcon(getNightModeIcon());
-        }else if (item.getTitle()
-                    .equals("Download")) {
-	showDialog(DOWNLOAD_DIALOG_ID);
+            return true;
+        case R.id.browse_menu_settings:
+            Intent settingsIntent = new Intent(this, PreferencesActivity.class);
+            this.startActivity(settingsIntent);
 
             return true;
-        } else if (item.getTitle()
-                           .equals("Settings")) {
-            Intent i = new Intent(this, PreferencesActivity.class);
-            this.startActivity(i);
-
-            return true;
-        } else if (item.getTitle()
-                           .equals("Crosswords") || item.getTitle()
-                                                            .equals(MENU_ARCHIVES)) {
+        case R.id.browse_menu_archives:
             this.viewArchive = !viewArchive;
             item.setTitle(viewArchive ? "Crosswords" : MENU_ARCHIVES); //menu item title
             this.setTitle(!viewArchive ? "Puzzles" : MENU_ARCHIVES); //activity title
@@ -271,44 +249,44 @@ public class BrowseActivity extends ForkyzActivity implements RecyclerItemClickL
             render();
 
             return true;
-        } else if (item.getTitle()
-                           .equals("Cleanup")) {
+        case R.id.browse_menu_cleanup:
             this.cleanup();
 
             return true;
-        } else if (item.getTitle()
-                           .equals("Help")) {
-            Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse("file:///android_asset/filescreen.html"), this,
+        case R.id.browse_menu_help:
+            Intent helpIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("file:///android_asset/filescreen.html"), this,
                     HTMLActivity.class);
-            this.startActivity(i);
-        } else if (item.getTitle()
-                           .equals("By Source")) {
+            this.startActivity(helpIntent);
+            return true;
+        case R.id.browse_menu_sort_source:
             this.accessor = Accessor.SOURCE;
             prefs.edit()
                  .putInt("sort", 2)
                  .apply();
             this.render();
-        } else if (item.getTitle()
-                           .equals("By Date (Ascending)")) {
+            return true;
+        case R.id.browse_menu_sort_date_asc:
             this.accessor = Accessor.DATE_ASC;
             prefs.edit()
                  .putInt("sort", 1)
                  .apply();
             this.render();
-        } else if (item.getTitle()
-                           .equals("By Date (Descending)")) {
+            return true;
+        case R.id.browse_menu_sort_date_desc:
             this.accessor = Accessor.DATE_DESC;
             prefs.edit()
                  .putInt("sort", 0)
                  .apply();
             this.render();
+            return true;
         }
 
-        return false;
+        return super.onOptionsItemSelected(item);
     }
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
         if ((resultCode == RESULT_OK) && (downloadDialog != null) && downloadDialog.isShowing()) {
             // If the user hit close in the browser download activity, we close the dialog.
             downloadDialog.dismiss();

--- a/app/src/main/java/app/crossword/yourealwaysbe/ClueListActivity.java
+++ b/app/src/main/java/app/crossword/yourealwaysbe/ClueListActivity.java
@@ -9,6 +9,7 @@ import android.util.DisplayMetrics;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -42,15 +43,15 @@ public class ClueListActivity extends PuzzleActivity
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if(item == null || item.getItemId() == android.R.id.home) {
+        switch (item.getItemId()) {
+        case android.R.id.home:
             finish();
             return true;
-        } else if (item.getTitle().toString().equals("Notes")) {
+        case R.id.clue_list_menu_notes:
             launchNotes();
             return true;
-        } else {
-            return super.onOptionsItemSelected(item);
         }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override
@@ -141,7 +142,8 @@ public class ClueListActivity extends PuzzleActivity
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        menu.add("Notes").setIcon(android.R.drawable.ic_menu_agenda);
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.clue_list_menu, menu);
         return true;
     }
 

--- a/app/src/main/java/app/crossword/yourealwaysbe/PlayActivity.java
+++ b/app/src/main/java/app/crossword/yourealwaysbe/PlayActivity.java
@@ -465,22 +465,22 @@ public class PlayActivity extends PuzzleActivity
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuInflater inflater = getMenuInflater();
-        inflater.inflate(R.menu.options_menu, menu);
+        inflater.inflate(R.menu.play_menu, menu);
 
         if (getRenderer() == null || getRenderer().getScale() >= getRenderer().getDeviceMaxScale())
-            menu.removeItem(R.id.menu_zoom_in_max);
+            menu.removeItem(R.id.play_menu_zoom_in_max);
 
         Puzzle puz = getPuzzle();
         if (puz == null || puz.isUpdatable()) {
-            menu.findItem(R.id.menu_show_errors).setEnabled(false);
-            menu.findItem(R.id.menu_reveal).setEnabled(false);
+            menu.findItem(R.id.play_menu_show_errors).setEnabled(false);
+            menu.findItem(R.id.play_menu_reveal).setEnabled(false);
         } else {
-            menu.findItem(R.id.menu_show_errors).setChecked(this.showErrors);
+            menu.findItem(R.id.play_menu_show_errors).setChecked(this.showErrors);
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
                 if (ForkyzApplication.isTabletish(metrics)) {
-                    menu.findItem(R.id.menu_show_errors).setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT);
-                    menu.findItem(R.id.menu_reveal).setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT);
+                    menu.findItem(R.id.play_menu_show_errors).setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT);
+                    menu.findItem(R.id.play_menu_reveal).setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT);
                 }
             }
         }
@@ -576,30 +576,30 @@ public class PlayActivity extends PuzzleActivity
         case android.R.id.home:
             finish();
             return true;
-        case R.id.menu_reveal_letter:
+        case R.id.play_menu_reveal_letter:
             getBoard().revealLetter();
             return true;
-        case R.id.menu_reveal_word:
+        case R.id.play_menu_reveal_word:
             getBoard().revealWord();
             return true;
-        case R.id.menu_reveal_errors:
+        case R.id.play_menu_reveal_errors:
             getBoard().revealErrors();
             return true;
-        case R.id.menu_reveal_puzzle:
+        case R.id.play_menu_reveal_puzzle:
             this.showDialog(REVEAL_PUZZLE_DIALOG);
             return true;
-        case R.id.menu_show_errors:
+        case R.id.play_menu_show_errors:
             getBoard().toggleShowErrors();
             item.setChecked(getBoard().isShowErrors());
             this.prefs.edit().putBoolean("showErrors", getBoard().isShowErrors())
                     .apply();
             return true;
-        case R.id.menu_settings:
+        case R.id.play_menu_settings:
             Intent i = new Intent(this, PreferencesActivity.class);
             this.startActivity(i);
 
             return true;
-        case R.id.menu_zoom_in:
+        case R.id.play_menu_zoom_in:
             this.boardView.scrollTo(0, 0);
             {
                 float newScale = getRenderer().zoomIn();
@@ -610,7 +610,7 @@ public class PlayActivity extends PuzzleActivity
             this.render(true);
 
             return true;
-        case R.id.menu_zoom_in_max:
+        case R.id.play_menu_zoom_in_max:
             this.boardView.scrollTo(0, 0);
             {
                 float newScale = getRenderer().zoomInMax();
@@ -621,7 +621,7 @@ public class PlayActivity extends PuzzleActivity
             this.render(true);
 
             return true;
-        case R.id.menu_zoom_out:
+        case R.id.play_menu_zoom_out:
             this.boardView.scrollTo(0, 0);
             {
                 float newScale = getRenderer().zoomOut();
@@ -632,11 +632,11 @@ public class PlayActivity extends PuzzleActivity
             this.render(true);
 
             return true;
-        case R.id.menu_zoom_fit:
+        case R.id.play_menu_zoom_fit:
             fitToScreen();
 
             return true;
-        case R.id.menu_zoom_reset:
+        case R.id.play_menu_zoom_reset:
             float newScale = getRenderer().zoomReset();
             boardView.setCurrentScale(newScale);
             this.prefs.edit().putFloat(SCALE, newScale).apply();
@@ -644,7 +644,7 @@ public class PlayActivity extends PuzzleActivity
             this.boardView.scrollTo(0, 0);
 
             return true;
-        case R.id.menu_info:
+        case R.id.play_menu_info:
             if (dialog != null) {
                 TextView view = (TextView) dialog
                         .findViewById(R.id.puzzle_info_time);
@@ -667,26 +667,26 @@ public class PlayActivity extends PuzzleActivity
             this.showDialog(INFO_DIALOG);
 
             return true;
-        case R.id.menu_clues:
+        case R.id.play_menu_clues:
             Intent clueIntent = new Intent(PlayActivity.this, ClueListActivity.class);
             PlayActivity.this.startActivityForResult(clueIntent, 0);
             return true;
-        case R.id.menu_notes:
+        case R.id.play_menu_notes:
             launchNotes();
             return true;
-        case R.id.menu_help:
+        case R.id.play_menu_help:
             Intent helpIntent = new Intent(Intent.ACTION_VIEW,
                     Uri.parse("file:///android_asset/playscreen.html"), this,
                     HTMLActivity.class);
             this.startActivity(helpIntent);
             return true;
-        case R.id.menu_clue_size_s:
+        case R.id.play_menu_clue_size_s:
             this.setClueSize(12);
             return true;
-        case R.id.menu_clue_size_m:
+        case R.id.play_menu_clue_size_m:
             this.setClueSize(14);
             return true;
-        case R.id.menu_clue_size_l:
+        case R.id.play_menu_clue_size_l:
             this.setClueSize(16);
             return true;
         }

--- a/app/src/main/java/app/crossword/yourealwaysbe/PlayActivity.java
+++ b/app/src/main/java/app/crossword/yourealwaysbe/PlayActivity.java
@@ -485,57 +485,6 @@ public class PlayActivity extends PuzzleActivity
             }
         }
         return true;
-        /*
-        menu.add("Clues").setIcon(android.R.drawable.ic_menu_agenda);
-        menu.add("Notes").setIcon(android.R.drawable.ic_menu_agenda);
-
-        Menu zoom = menu.addSubMenu("Zoom");
-        zoom.add(createSpannableForMenu("Zoom In")).setTitleCondensed("Zoom In");
-
-        if (getRenderer() != null && getRenderer().getScale() < getRenderer().getDeviceMaxScale())
-            zoom.add(createSpannableForMenu("Zoom In Max")).setTitleCondensed("Zoom In Max");
-
-        zoom.add(createSpannableForMenu("Zoom Out")).setTitleCondensed("Zoom Out");
-        zoom.add(createSpannableForMenu("Fit to Screen")).setTitleCondensed("Fit to Screen");
-        zoom.add(createSpannableForMenu("Zoom Reset")).setTitleCondensed("Zoom Reset");
-
-        Menu clueSize = menu.addSubMenu("Clue Text Size");
-        clueSize.add(createSpannableForMenu("Small")).setTitleCondensed("Small");
-        clueSize.add(createSpannableForMenu("Medium")).setTitleCondensed("Medium");
-        clueSize.add(createSpannableForMenu("Large")).setTitleCondensed("Large");
-
-        Puzzle puz = getPuzzle();
-        if (puz != null && !puz.isUpdatable()) {
-            MenuItem showItem = menu.add(
-                    this.showErrors ? "Hide Errors" : "Show Errors").setIcon(
-                    android.R.drawable.ic_menu_view);
-            if (ForkyzApplication.isTabletish(metrics)) {
-                utils.onActionBarWithText(showItem);
-            }
-
-            SubMenu reveal = menu.addSubMenu("Reveal").setIcon(
-                    android.R.drawable.ic_menu_view);
-            reveal.add(createSpannableForMenu("Letter")).setTitleCondensed("Letter");
-            reveal.add(createSpannableForMenu("Word")).setTitleCondensed("Word");
-            reveal.add(createSpannableForMenu("Errors")).setTitleCondensed("Errors");
-            reveal.add(createSpannableForMenu("Puzzle")).setTitleCondensed("Puzzle");
-            if (ForkyzApplication.isTabletish(metrics)) {
-                utils.onActionBarWithText(reveal);
-            }
-        } else {
-            menu.add("Show Errors").setEnabled(false)
-                    .setIcon(android.R.drawable.ic_menu_view);
-            menu.add("Reveal").setIcon(android.R.drawable.ic_menu_view)
-                    .setEnabled(false);
-        }
-
-        menu.add("Info").setIcon(android.R.drawable.ic_menu_info_details);
-        menu.add("Help").setIcon(android.R.drawable.ic_menu_help);
-        menu.add("Settings").setIcon(android.R.drawable.ic_menu_preferences);
-
-        return true;
-
-         */
     }
 
     private SpannableString createSpannableForMenu(String value){

--- a/app/src/main/res/menu/browse_menu.xml
+++ b/app/src/main/res/menu/browse_menu.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/browse_menu_app_theme"
+        android:icon="@drawable/system_daynight_mode"
+        android:title="App Theme"
+        app:showAsAction="always" />
+    <item
+        android:id="@+id/browse_menu_sort"
+        android:icon="@android:drawable/ic_menu_sort_alphabetically"
+        android:title="Sort"
+        app:showAsAction="withText" >
+        <menu>
+            <item
+                android:id="@+id/browse_menu_sort_date_desc"
+                android:title="By Date (Descending)" />
+            <item
+                android:id="@+id/browse_menu_sort_date_asc"
+                android:title="By Date (Ascending)" />
+            <item
+                android:id="@+id/browse_menu_sort_source"
+                android:title="By Source" />
+        </menu>
+    </item>
+    <item
+        android:id="@+id/browse_menu_cleanup"
+        android:icon="@android:drawable/ic_menu_manage"
+        android:title="Cleanup" />
+    <item
+        android:id="@+id/browse_menu_archives"
+        android:icon="@android:drawable/ic_menu_view"
+        android:title="Archives" />
+    <item
+        android:id="@+id/browse_menu_help"
+        android:icon="@android:drawable/ic_menu_help"
+        android:title="Help" />
+    <item
+        android:id="@+id/browse_menu_settings"
+        android:icon="@android:drawable/ic_menu_preferences"
+        android:title="Settings" />
+</menu>

--- a/app/src/main/res/menu/clue_list_menu.xml
+++ b/app/src/main/res/menu/clue_list_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/clue_list_menu_notes"
+        android:icon="@android:drawable/ic_menu_agenda"
+        android:title="Notes" />
+
+</menu>

--- a/app/src/main/res/menu/options_menu.xml
+++ b/app/src/main/res/menu/options_menu.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/menu_clues"
+        android:icon="@android:drawable/ic_menu_agenda"
+        android:title="Clues" />
+    <item
+        android:id="@+id/menu_notes"
+        android:icon="@android:drawable/ic_menu_agenda"
+        android:title="Notes" />
+    <item
+        android:id="@+id/menu_zoom"
+        android:title="Zoom" >
+        <menu>
+            <item
+                android:id="@+id/menu_zoom_in"
+                android:title="Zoom In" />
+            <item
+                android:id="@+id/menu_zoom_in_max"
+                android:title="Zoom In Max" />
+            <item
+                android:id="@+id/menu_zoom_out"
+                android:title="Zoom Out" />
+            <item
+                android:id="@+id/menu_zoom_fit"
+                android:title="Fit to Screen" />
+            <item
+                android:id="@+id/menu_zoom_reset"
+                android:title="Zoom Reset" />
+        </menu>
+    </item>
+    <item
+        android:id="@+id/menu_clue_size"
+        android:title="Clue Text Size" >
+        <menu>
+            <item
+                android:id="@+id/menu_clue_size_s"
+                android:title="Small" />
+            <item
+                android:id="@+id/menu_clue_size_m"
+                android:title="Medium" />
+            <item
+                android:id="@+id/menu_clue_size_l"
+                android:title="Large" />
+        </menu>
+    </item>
+    <item
+        android:id="@+id/menu_show_errors"
+        android:icon="@android:drawable/ic_menu_view"
+        android:title="Show Errors"
+        android:checkable="true" />
+    <item
+        android:id="@+id/menu_reveal"
+        android:icon="@android:drawable/ic_menu_view"
+        android:title="Reveal" >
+        <menu>
+            <item
+                android:id="@+id/menu_reveal_letter"
+                android:title="Letter" />
+            <item
+                android:id="@+id/menu_reveal_word"
+                android:title="Word" />
+            <item
+                android:id="@+id/menu_reveal_errors"
+                android:title="Errors" />
+            <item
+                android:id="@+id/menu_reveal_puzzle"
+                android:title="Puzzle" />
+
+        </menu>
+    </item>
+    <item
+        android:id="@+id/menu_info"
+        android:icon="@android:drawable/ic_menu_info_details"
+        android:title="Info" />
+    <item
+        android:id="@+id/menu_help"
+        android:icon="@android:drawable/ic_menu_help"
+        android:title="Help" />
+    <item
+        android:id="@+id/menu_settings"
+        android:icon="@android:drawable/ic_menu_preferences"
+        android:title="Settings" />
+</menu>

--- a/app/src/main/res/menu/play_menu.xml
+++ b/app/src/main/res/menu/play_menu.xml
@@ -3,84 +3,84 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
-        android:id="@+id/menu_clues"
+        android:id="@+id/play_menu_clues"
         android:icon="@android:drawable/ic_menu_agenda"
         android:title="Clues" />
     <item
-        android:id="@+id/menu_notes"
+        android:id="@+id/play_menu_notes"
         android:icon="@android:drawable/ic_menu_agenda"
         android:title="Notes" />
     <item
-        android:id="@+id/menu_zoom"
+        android:id="@+id/play_menu_zoom"
         android:title="Zoom" >
         <menu>
             <item
-                android:id="@+id/menu_zoom_in"
+                android:id="@+id/play_menu_zoom_in"
                 android:title="Zoom In" />
             <item
-                android:id="@+id/menu_zoom_in_max"
+                android:id="@+id/play_menu_zoom_in_max"
                 android:title="Zoom In Max" />
             <item
-                android:id="@+id/menu_zoom_out"
+                android:id="@+id/play_menu_zoom_out"
                 android:title="Zoom Out" />
             <item
-                android:id="@+id/menu_zoom_fit"
+                android:id="@+id/play_menu_zoom_fit"
                 android:title="Fit to Screen" />
             <item
-                android:id="@+id/menu_zoom_reset"
+                android:id="@+id/play_menu_zoom_reset"
                 android:title="Zoom Reset" />
         </menu>
     </item>
     <item
-        android:id="@+id/menu_clue_size"
+        android:id="@+id/play_menu_clue_size"
         android:title="Clue Text Size" >
         <menu>
             <item
-                android:id="@+id/menu_clue_size_s"
+                android:id="@+id/play_menu_clue_size_s"
                 android:title="Small" />
             <item
-                android:id="@+id/menu_clue_size_m"
+                android:id="@+id/play_menu_clue_size_m"
                 android:title="Medium" />
             <item
-                android:id="@+id/menu_clue_size_l"
+                android:id="@+id/play_menu_clue_size_l"
                 android:title="Large" />
         </menu>
     </item>
     <item
-        android:id="@+id/menu_show_errors"
+        android:id="@+id/play_menu_show_errors"
         android:icon="@android:drawable/ic_menu_view"
         android:title="Show Errors"
         android:checkable="true" />
     <item
-        android:id="@+id/menu_reveal"
+        android:id="@+id/play_menu_reveal"
         android:icon="@android:drawable/ic_menu_view"
         android:title="Reveal" >
         <menu>
             <item
-                android:id="@+id/menu_reveal_letter"
+                android:id="@+id/play_menu_reveal_letter"
                 android:title="Letter" />
             <item
-                android:id="@+id/menu_reveal_word"
+                android:id="@+id/play_menu_reveal_word"
                 android:title="Word" />
             <item
-                android:id="@+id/menu_reveal_errors"
+                android:id="@+id/play_menu_reveal_errors"
                 android:title="Errors" />
             <item
-                android:id="@+id/menu_reveal_puzzle"
+                android:id="@+id/play_menu_reveal_puzzle"
                 android:title="Puzzle" />
 
         </menu>
     </item>
     <item
-        android:id="@+id/menu_info"
+        android:id="@+id/play_menu_info"
         android:icon="@android:drawable/ic_menu_info_details"
         android:title="Info" />
     <item
-        android:id="@+id/menu_help"
+        android:id="@+id/play_menu_help"
         android:icon="@android:drawable/ic_menu_help"
         android:title="Help" />
     <item
-        android:id="@+id/menu_settings"
+        android:id="@+id/play_menu_settings"
         android:icon="@android:drawable/ic_menu_preferences"
         android:title="Settings" />
 </menu>


### PR DESCRIPTION
This is a straightforward refactoring to use resource files for menus.  The only functional change is that the "Show Errors" option now has a checkbox in the menu instead of toggling between "Show Errors" / "Hide Errors".

Just wanted to get this change in prior to adding an option for Scratch text entry in the PlayActivity.