### PR TITLE
Add a "scratch" mode to the play board

### DIFF
--- a/app/src/main/java/app/crossword/yourealwaysbe/NotesActivity.java
+++ b/app/src/main/java/app/crossword/yourealwaysbe/NotesActivity.java
@@ -82,6 +82,7 @@ public class NotesActivity extends PuzzleActivity {
             this.renderer.setScale((float) 1);
 
         Playboard board = getBoard();
+        board.setScratchMode(false);
         Puzzle puz = board.getPuzzle();
 
         setContentView(R.layout.notes);

--- a/app/src/main/java/app/crossword/yourealwaysbe/NotesActivity.java
+++ b/app/src/main/java/app/crossword/yourealwaysbe/NotesActivity.java
@@ -82,7 +82,6 @@ public class NotesActivity extends PuzzleActivity {
             this.renderer.setScale((float) 1);
 
         Playboard board = getBoard();
-        board.setScratchMode(false);
         Puzzle puz = board.getPuzzle();
 
         setContentView(R.layout.notes);

--- a/app/src/main/java/app/crossword/yourealwaysbe/PlayActivity.java
+++ b/app/src/main/java/app/crossword/yourealwaysbe/PlayActivity.java
@@ -419,10 +419,6 @@ public class PlayActivity extends PuzzleActivity
             getBoard().toggleShowErrors();
         }
 
-        if (getBoard().isScratchMode() != this.scratchMode) {
-            getBoard().toggleScratchMode();
-        }
-
         this.clueTabs = this.findViewById(R.id.playClueTab);
         this.clueTabs.setBoard(getBoard());
         this.clueTabs.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
@@ -544,6 +540,8 @@ public class PlayActivity extends PuzzleActivity
             case KeyEvent.KEYCODE_SPACE:
                 if (prefs.getBoolean("spaceChangesDirection", true)) {
                     getBoard().toggleDirection();
+                } else if (this.scratchMode) {
+                    getBoard().playScratchLetter(' ');
                 } else {
                     getBoard().playLetter(' ');
                 }
@@ -558,14 +556,22 @@ public class PlayActivity extends PuzzleActivity
                 return true;
 
             case KeyEvent.KEYCODE_DEL:
-                getBoard().deleteLetter();
+                if (this.scratchMode) {
+                    getBoard().deleteScratchLetter();
+                } else {
+                    getBoard().deleteLetter();
+                }
                 return true;
         }
 
         char c = Character.toUpperCase(event.getDisplayLabel());
 
         if (ALPHA.indexOf(c) != -1) {
-            getBoard().playLetter(c);
+            if (this.scratchMode) {
+                getBoard().playScratchLetter(c);
+            } else {
+                getBoard().playLetter(c);
+            }
             return true;
         }
 
@@ -603,9 +609,9 @@ public class PlayActivity extends PuzzleActivity
                     .apply();
             return true;
         case R.id.play_menu_scratch_mode:
-            getBoard().toggleScratchMode();
-            item.setChecked(getBoard().isScratchMode());
-            this.prefs.edit().putBoolean("scratchMode", getBoard().isScratchMode()).apply();
+            this.scratchMode = !this.scratchMode;
+            item.setChecked(this.scratchMode);
+            this.prefs.edit().putBoolean("scratchMode", this.scratchMode).apply();
             return true;
         case R.id.play_menu_settings:
             Intent i = new Intent(this, PreferencesActivity.class);

--- a/app/src/main/java/app/crossword/yourealwaysbe/PlayActivity.java
+++ b/app/src/main/java/app/crossword/yourealwaysbe/PlayActivity.java
@@ -82,6 +82,7 @@ public class PlayActivity extends PuzzleActivity
 
     private boolean showCount = false;
     private boolean showErrors = false;
+    private boolean scratchMode = false;
     private long lastTap = 0;
     private int screenWidthInInches;
     private Runnable fitToScreenTask = new Runnable() {
@@ -140,6 +141,7 @@ public class PlayActivity extends PuzzleActivity
         utils.finishOnHomeButton(this);
 
         this.showErrors = this.prefs.getBoolean("showErrors", false);
+        this.scratchMode = this.prefs.getBoolean("scratchMode", false);
         setDefaultKeyMode(Activity.DEFAULT_KEYS_DISABLE);
 
         MovementStrategy movement = this.getMovementStrategy();
@@ -417,6 +419,10 @@ public class PlayActivity extends PuzzleActivity
             getBoard().toggleShowErrors();
         }
 
+        if (getBoard().isScratchMode() != this.scratchMode) {
+            getBoard().toggleScratchMode();
+        }
+
         this.clueTabs = this.findViewById(R.id.playClueTab);
         this.clueTabs.setBoard(getBoard());
         this.clueTabs.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
@@ -484,6 +490,8 @@ public class PlayActivity extends PuzzleActivity
                 }
             }
         }
+
+        menu.findItem(R.id.play_menu_scratch_mode).setChecked(this.scratchMode);
         return true;
     }
 
@@ -593,6 +601,11 @@ public class PlayActivity extends PuzzleActivity
             item.setChecked(getBoard().isShowErrors());
             this.prefs.edit().putBoolean("showErrors", getBoard().isShowErrors())
                     .apply();
+            return true;
+        case R.id.play_menu_scratch_mode:
+            getBoard().toggleScratchMode();
+            item.setChecked(getBoard().isScratchMode());
+            this.prefs.edit().putBoolean("scratchMode", getBoard().isScratchMode()).apply();
             return true;
         case R.id.play_menu_settings:
             Intent i = new Intent(this, PreferencesActivity.class);

--- a/app/src/main/res/menu/play_menu.xml
+++ b/app/src/main/res/menu/play_menu.xml
@@ -52,6 +52,10 @@
         android:title="Show Errors"
         android:checkable="true" />
     <item
+        android:id="@+id/play_menu_scratch_mode"
+        android:title="Scratch Mode"
+        android:checkable="true" />
+    <item
         android:id="@+id/play_menu_reveal"
         android:icon="@android:drawable/ic_menu_view"
         android:title="Reveal" >

--- a/puzlib/src/main/java/app/crossword/yourealwaysbe/io/IO.java
+++ b/puzlib/src/main/java/app/crossword/yourealwaysbe/io/IO.java
@@ -785,8 +785,10 @@ public class IO {
                 }
             }
 
-            Note n = new Note(scratch, text, anagramSrc, anagramSol);
-            puz.setNoteRaw(n, x, isAcross);
+            if (scratch != null || text != null || anagramSrc != null || anagramSol != null) {
+                Note n = new Note(scratch, text, anagramSrc, anagramSol);
+                puz.setNoteRaw(n, x, isAcross);
+            }
         }
     }
 }

--- a/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Box.java
+++ b/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Box.java
@@ -3,7 +3,7 @@ package app.crossword.yourealwaysbe.puz;
 import java.io.Serializable;
 
 public class Box implements Serializable {
-    private static final char BLANK = ' ';
+    public static final char BLANK = ' ';
     private static final int NOCLUE = -1;
 
     private String responder;

--- a/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Note.java
+++ b/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Note.java
@@ -1,6 +1,7 @@
 package app.crossword.yourealwaysbe.puz;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 public class Note implements Serializable {
     private String scratch;
@@ -16,6 +17,16 @@ public class Note implements Serializable {
         this.scratch = scratch;
         this.anagramSource = anagramSource;
         this.anagramSolution = anagramSolution;
+    }
+
+    public Note(String text) {
+        this.text = text;
+
+        String blankString = createBlankString(text.length());
+        this.scratch
+                = this.anagramSource
+                = this.anagramSolution
+                = blankString;
     }
 
     public String getText() {
@@ -92,5 +103,28 @@ public class Note implements Serializable {
         } else {
             return s1.equals(s2);
         }
+    }
+
+    private String createBlankString(int len) {
+        if (len == 0) return "";
+
+        char[] padding = new char[len];
+        Arrays.fill(padding, Box.BLANK);
+        return new String(padding);
+    }
+
+    public void setScratchLetter(int pos, char letter) {
+        String letterText = Character.toString(letter);
+        String newScratchText;
+
+        int len = scratch.length();
+        if (pos == 0) {
+            newScratchText = letterText + scratch.substring(1);
+        } else if (pos == len - 1) {
+            newScratchText = scratch.substring(0, pos) + letterText;
+        } else {
+            newScratchText = scratch.substring(0, pos) + letterText + scratch.substring(pos + 1);
+        }
+        scratch = newScratchText;
     }
 }

--- a/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Note.java
+++ b/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Note.java
@@ -2,8 +2,12 @@ package app.crossword.yourealwaysbe.puz;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.logging.Logger;
+
+import app.crossword.yourealwaysbe.io.charset.Surrogate;
 
 public class Note implements Serializable {
+    private static final Logger LOG = Logger.getLogger(Note.class.getCanonicalName());
     private String scratch;
     private String text;
     private String anagramSource;
@@ -113,9 +117,19 @@ public class Note implements Serializable {
         return new String(padding);
     }
 
-    public void setScratchLetter(int pos, char letter) {
+    public void setScratchLetter(int pos, char letter, int wordLength) {
         String letterText = Character.toString(letter);
         String newScratchText;
+
+        if (scratch == null && wordLength > 0)
+            scratch = createBlankString(wordLength);
+
+        // If a wordLength isn't supplied and we don't have a scratch already created, we can't do
+        // anything.  Swallow the error and log it.
+        if (scratch == null) {
+            LOG.warning("Can't set scratch letter because scratch text not created");
+            return;
+        }
 
         int len = scratch.length();
         if (pos == 0) {
@@ -126,5 +140,9 @@ public class Note implements Serializable {
             newScratchText = scratch.substring(0, pos) + letterText + scratch.substring(pos + 1);
         }
         scratch = newScratchText;
+    }
+
+    public void deleteScratchLetterAt(int pos) {
+        setScratchLetter(pos, Box.BLANK, 0);
     }
 }

--- a/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Note.java
+++ b/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Note.java
@@ -23,14 +23,8 @@ public class Note implements Serializable {
         this.anagramSolution = anagramSolution;
     }
 
-    public Note(String text) {
-        this.text = text;
-
-        String blankString = createBlankString(text.length());
-        this.scratch
-                = this.anagramSource
-                = this.anagramSolution
-                = blankString;
+    public Note(int wordLength) {
+        this.scratch = createBlankString(wordLength);
     }
 
     public String getText() {
@@ -117,15 +111,10 @@ public class Note implements Serializable {
         return new String(padding);
     }
 
-    public void setScratchLetter(int pos, char letter, int wordLength) {
+    public void setScratchLetter(int pos, char letter) {
         String letterText = Character.toString(letter);
         String newScratchText;
 
-        if (scratch == null && wordLength > 0)
-            scratch = createBlankString(wordLength);
-
-        // If a wordLength isn't supplied and we don't have a scratch already created, we can't do
-        // anything.  Swallow the error and log it.
         if (scratch == null) {
             LOG.warning("Can't set scratch letter because scratch text not created");
             return;
@@ -143,6 +132,6 @@ public class Note implements Serializable {
     }
 
     public void deleteScratchLetterAt(int pos) {
-        setScratchLetter(pos, Box.BLANK, 0);
+        setScratchLetter(pos, Box.BLANK);
     }
 }

--- a/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Playboard.java
+++ b/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Playboard.java
@@ -396,6 +396,14 @@ public class Playboard implements Serializable {
         return responder;
     }
 
+    public boolean isScratchMode() {
+        return scratchMode;
+    }
+
+    public void toggleScratchMode() {
+        this.scratchMode = !this.scratchMode;
+    }
+
     public void setShowErrors(boolean showErrors) {
         boolean changed = (this.showErrors != showErrors);
         this.showErrors = showErrors;

--- a/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Playboard.java
+++ b/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Playboard.java
@@ -400,6 +400,8 @@ public class Playboard implements Serializable {
         return scratchMode;
     }
 
+    public void setScratchMode(boolean scratchMode) { this.scratchMode = scratchMode; }
+
     public void toggleScratchMode() {
         this.scratchMode = !this.scratchMode;
     }

--- a/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Playboard.java
+++ b/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Playboard.java
@@ -774,7 +774,7 @@ public class Playboard implements Serializable {
 
             // Create a note for this clue if we don't already have one
             if (note == null) {
-                note = new Note(response);
+                note = new Note(response.length());
                 Clue c = this.getClue();
                 this.puzzle.setNote(note, c.number, this.across);
             }
@@ -782,7 +782,7 @@ public class Playboard implements Serializable {
             // Update the scratch text
             int pos = this.across ? b.getAcrossPosition() : b.getDownPosition();
             if (pos >= 0 && pos < response.length())
-                note.setScratchLetter(pos, letter, response.length());
+                note.setScratchLetter(pos, letter);
 
             Word next = this.nextLetter();
             popNotificationDisabled();

--- a/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Playboard.java
+++ b/puzlib/src/main/java/app/crossword/yourealwaysbe/puz/Playboard.java
@@ -516,20 +516,29 @@ public class Playboard implements Serializable {
      * -Delete the letter in the current box.
      */
     public Word deleteLetter() {
-        // TODO: Handle deletion of scratch letters
         Box currentBox = this.getCurrentBox();
         Word wordToReturn = this.getCurrentWord();
 
         pushNotificationDisabled();
 
+        if (this.scratchMode && currentBox.isBlank()) {
+            Note note = this.getNote();
+            if (note != null) {
+                // Update the scratch text
+                int pos = this.across ? currentBox.getAcrossPosition() : currentBox.getDownPosition();
+                String response = this.getCurrentWordResponse();
+                if (pos >= 0 && pos < response.length())
+                    note.deleteScratchLetterAt(pos);
+            }
+        }
 
-        if (currentBox.isBlank() || isDontDeleteCurrent()) {
+        if (currentBox.isBlank() || isDontDeleteCurrent() || this.scratchMode) {
             wordToReturn = this.previousLetter();
             currentBox = this.boxes[this.highlightLetter.across][this.highlightLetter.down];
         }
 
 
-        if (!isDontDeleteCurrent()) {
+        if (!isDontDeleteCurrent() && !this.scratchMode) {
             currentBox.setBlank();
         }
 
@@ -765,7 +774,7 @@ public class Playboard implements Serializable {
             // Update the scratch text
             int pos = this.across ? b.getAcrossPosition() : b.getDownPosition();
             if (pos >= 0 && pos < response.length())
-                note.setScratchLetter(pos, letter);
+                note.setScratchLetter(pos, letter, response.length());
 
             Word next = this.nextLetter();
             popNotificationDisabled();


### PR DESCRIPTION
This adds a "Scratch mode" option to the menu on the play board.  Anything you type in the play board while in scratch mode goes directly into the scratch field on the notes.  Delete works as well, and won't delete non-scratch letters.

Movement logic could definitely be improved in the future to skip over non-scratch letters that have already been entered into the board, but that would required changes to the movement strategies and I thought this PR was already complicated enough.  Another future improvement would be to add the same option to the Clue List view.