### PR TITLE
Custom daily sources

### DIFF
--- a/app/src/main/java/app/crossword/yourealwaysbe/net/CustomDailyDownloader.java
+++ b/app/src/main/java/app/crossword/yourealwaysbe/net/CustomDailyDownloader.java
@@ -1,0 +1,46 @@
+package app.crossword.yourealwaysbe.net;
+
+import android.content.SharedPreferences;
+
+import java.time.format.DateTimeFormatter;
+import java.time.LocalDate;
+
+import app.crossword.yourealwaysbe.forkyz.ForkyzApplication;
+import app.crossword.yourealwaysbe.forkyz.R;
+import app.crossword.yourealwaysbe.io.IO;
+
+/**
+ * Custom daily downloader
+ * URL: prefs.getString("customDailyLink", "")
+ * Date = Daily
+ */
+public class CustomDailyDownloader extends AbstractDownloader {
+    private static final String NAME
+        = ForkyzApplication.getInstance().getString(R.string.custom_daily_title);
+    private static final String SUPPORT_URL = "https://github.com/yourealwaysbe/forkyz";
+    private DateTimeFormatter df;
+
+    private static String puzzleTitle(SharedPreferences prefs) {
+        String title = prefs.getString("customDailyTitle", NAME);
+        if (title.trim().isEmpty())
+            return NAME;
+        return title;
+    }
+
+    public CustomDailyDownloader(SharedPreferences prefs) {
+        super(
+            "",
+            puzzleTitle(prefs),
+            DATE_DAILY,
+            SUPPORT_URL,
+            new IO()
+        );
+
+        this.df = DateTimeFormatter.ofPattern( prefs.getString("customDailyLink", "") );
+    }
+
+    @Override
+    protected String createUrlSuffix(LocalDate date) {
+        return df.format(date);
+    }
+}

--- a/app/src/main/java/app/crossword/yourealwaysbe/net/Downloaders.java
+++ b/app/src/main/java/app/crossword/yourealwaysbe/net/Downloaders.java
@@ -353,6 +353,10 @@ public class Downloaders {
             ));
         }
 
+        if (prefs.getBoolean("downloadCustomDaily", true)) {
+            downloaders.add(new CustomDailyDownloader(prefs));
+        }
+
         if (prefs.getBoolean("downloadWsj", true)) {
             downloaders.add(new WSJFridayDownloader());
             downloaders.add(new WSJSaturdayDownloader());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -206,6 +206,17 @@
     <string name="keglars_cryptics">Kegler\'s Kryptics</string>
     <string name="keglars_cryptics_desc">Ron &quot;Kegler&quot; Sweet\'s Cryptic Archive\nhttps://kegler.gitlab.io/Block_style/index.html\n(Please Read the help item below)</string>
     <string name="about_scrapes">About These Sources</string>
+    
+    <!-- preferences custom -->
+    <string name="custom_daily">Custom daily source</string>
+    <string name="custom_daily_title">Custom daily</string>
+    <string name="custom_weekly">Custom weekly source</string>
+    <string name="custom">Select source</string>
+    <string name="custom_desc">Specify source link below</string>
+    <string name="custom_title">Puzzle name</string>
+    <string name="custom_title_desc">Enter title for puzzle list</string>
+    <string name="custom_link">Source link</string>
+    <string name="custom_link_desc">Enter link formatted according to Java\'s DateTimeFormatter</string>
 
     <!-- menus general -->
     <string name="help">Help</string>

--- a/app/src/main/res/xml/preferences_daily.xml
+++ b/app/src/main/res/xml/preferences_daily.xml
@@ -50,4 +50,26 @@
         android:summary="@string/updates_mon_sat"
         android:key="downloadUSAToday"
     />
+
+    <androidx.preference.PreferenceCategory
+        android:title="@string/custom_daily"
+    >
+        <androidx.preference.CheckBoxPreference
+            android:title="@string/custom"
+            android:defaultValue="false"
+            android:summary="@string/custom_desc"
+            android:key="downloadCustomDaily"
+        />
+        <androidx.preference.EditTextPreference
+            android:title="@string/custom_title"
+            android:summary="@string/custom_title_desc"
+            android:key="customDailyTitle"
+        />
+        <androidx.preference.EditTextPreference
+            android:title="@string/custom_link"
+            android:summary="@string/custom_link_desc"
+            android:key="customDailyLink"
+            android:inputType="textUri"
+        />
+    </androidx.preference.PreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Enable custom daily sources, with date formatting according to Java's [DateTimeFormat](https://docs.oracle.com/javase/7/docs/api/java/text/DateFormat.html)

Partially addresses #5; might be nice to select specific days of week rather than force daily.

NOTE: Doesn't seem to check for existing download?  Will get same puzzle multiple times if you select it.