### PR TITLE
Fix keyboard not working on initial clue list load

### DIFF
--- a/app/src/main/java/app/crossword/yourealwaysbe/ClueListActivity.java
+++ b/app/src/main/java/app/crossword/yourealwaysbe/ClueListActivity.java
@@ -154,6 +154,7 @@ public class ClueListActivity extends PuzzleActivity
         clueTabs.refresh();
 
         keyboardManager.onResume();
+        displayKeyboard();
 
         this.render();
     }

--- a/app/src/main/res/layout/clue_list.xml
+++ b/app/src/main/res/layout/clue_list.xml
@@ -25,5 +25,6 @@
         android:id="@+id/keyboard"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:visibility="gone"
     />
 </LinearLayout>


### PR DESCRIPTION
Fixes the keyboard not working after opening the clue list. Previously you needed to tap on a square on top before the keyboard would start working.

I'm not an Android or Java programmer and have no idea what I'm doing but this seems to work...